### PR TITLE
(fix) update demo script and litmus artefacts to ensure successful chaos

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,35 @@ To run the Litmus ChaosEngine experiments:
 ./manage.py test
 ```
 
+### Notes
+
+- To view application deployment picked, success/failure of reconcile operations (i.e., creation of chaos-runner pod or lack thereof), check
+the chaos operator logs. Ex:
+
+```bash
+kubectl logs -f chaos-operator-ce-6899bbdb9-jz6jv -n litmus  
+```
+
+- To view the parameters with which the experiment job is created, status of experiment, success of chaosengine patch operation and cleanup of 
+the experiment pod, check the logs of the chaos-runner pod. Ex:
+
+```bash
+kubectl logs sock-chaos-runner -n sock-shop
+```
+
+- To view the logs of the chaos experiment itself, use the value `retain` in `.spec.jobCleanupPolicy` of the chaosengine CR
+
+```bash
+kubectl logs container-kill-1oo8wv-85lsl -n sock-shop
+```
+
+- To re-run the chaosexperiment, cleanup and re-create the chaosengine CR
+
+```bash
+kubectl delete chaosengine sock-chaos -n sock-shop
+kubectl apply -f litmus/chaosengine.yaml 
+```
+
 ## Shutdown
 
 To shutdown and destroy the GKE cluster when you're finished:

--- a/litmus/chaosengine.yaml
+++ b/litmus/chaosengine.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   # It can be app/infra
   chaosType: 'app'
-  #ex. values: ns1:name=percona,ns2:run=nginx
+  #ex. values: sock-shop:name=carts
   auxiliaryAppInfo: ""
   components:
     runner:
@@ -14,11 +14,12 @@ spec:
       type: "go"
   # It can be delete/retain
   jobCleanUpPolicy: delete
-  monitoring: true
+  monitoring: false
   appinfo:
     appns: sock-shop
     # FYI, To see app label, apply kubectl get pods --show-labels
-    applabel: "app=sock-shop"
+    # unique-label of the application under test (AUT)
+    applabel: "name=carts-db"
     appkind: deployment
   chaosServiceAccount: sock-shop-chaos-engine
   experiments:

--- a/litmus/rbac.yaml
+++ b/litmus/rbac.yaml
@@ -7,24 +7,26 @@ metadata:
   labels:
     app: sock-shop
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: sock-shop-chaos-engine
+  namespace: sock-shop
 rules:
-- apiGroups: ["", "extensions", "apps", "batch", "litmuschaos.io"]
-  resources: ["daemonsets", "deployments", "replicasets", "jobs", "pods", "pods/exec","nodes","events", "chaosengines", "chaosexperiments", "chaosresults"]
-  verbs: ["*"]
+- apiGroups: ["", "apps", "batch", "litmuschaos.io"]
+  resources: ["daemonsets", "jobs", "pods", "pods/exec", "chaosengines", "chaosexperiments", "chaosresults"]
+  verbs: ["create","list","get","patch","update","delete"]
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: sock-shop-chaos-engine
+  namespace: sock-shop
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: sock-shop-chaos-engine
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: sock-shop-chaos-engine
-  namespace: sock-shop # App namespace
+  namespace: sock-shop 


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

## Issue 

These were the primary causes of the experiments not being executed: 

- (a) The chaosengine used the application label "app=sock-shop" which is shared by multiple other microservice deployments in the sock-shop stack. Each of these deployments were also annotated for chaos ("litmuschaos.io/chaos="true"). The LitmusChaos operator has been designed to desist from triggering chaos whenever multiple higher level deployments (not the pods belonging to them) with the same label are annotated. This is done to ensure there is no ambiguity wrt the experiment hypothesis or blast radius.  

```The script and manifests needed some changes, which have been explained in this PR: https://github.com/zebrium/zebrium-kubernetes-demo/pull/1
{"level":"info","ts":1579352531.0961246,"logger":"controller_chaosengine","msg":"Annotation check failed with","error:":"resource type 'deployment', err: too many deployments with specified label are annotated for chaos, either provide unique labels or annotate only desired app for chaos"}
```
- (b) The chaosexperiment custom resources were installed in the default namespace as part of the "start" operation, whereas they are expected to be installed in the same namespace as the application under test (AUT), sock-shop, just as with the chaosengine. All the experiment-related pods (chaos-runner/monitor, experiment job/pod) are created in the same namespace (the rbac used by the experiment might have namespaced or cluster scope, but the resources themselves are created in a specific i.e., AUT's namespace) 

## Changes

- This PR fixes (a) by using the label unique to the carts-db (`name=carts-db`) & (b) by installing the container-kill experiment into the sock-shop namespace

- The PR also makes the following minor enhancements:
  - Updates the RBAC with simpler, namespace scoped permissions as needed by the container-kill experiment 
  - Adds a status check for the experiment, before executing the command to obtain the result/verdict. Without this, the chaosresult describe command may fail on account of non-existing resource.   
  - Adds some notes to the "Test" section README explaining the procedure to view logs and re-run the experiment. 

The docs.litmuschaos.io is being updated with the above information and should be available soon! Thanks for the feedback :) !!  

## Logs

- Pod status showing restarts of the carts-db pod as a result of experiment runs

```
root@demo:~# kubectl get pods -n sock-shop
NAME                           READY   STATUS             RESTARTS   AGE
carts-745cc4588d-l5567         1/1     Running            0          43m
carts-db-5c5cf645-dksf7        1/1     Running            3          44m
catalogue-588c69c5-5c8tf       1/1     Running            0          43m
catalogue-db-69c55cc7d-5bjxm   1/1     Running            0          43m
front-end-6c8dcfc9f8-ktqhv     1/1     Running            0          43m
orders-58bd9bc54f-r2j92        1/1     Running            0          43m
orders-db-64ccc4548f-m2qg5     1/1     Running            0          43m
payment-7d6c9c5d65-24lfd       1/1     Running            0          43m
queue-master-885f98857-w4bwk   1/1     Running            0          43m
rabbitmq-d85bd565c-pgm54       1/1     Running            0          43m
shipping-855c7575f9-twgrb      1/1     Running            0          43m
sock-chaos-runner              0/1     Completed          0          16m
user-77dbc587d4-p597j          1/1     Running            0          43m
user-db-7f9789874b-wdxc8       1/1     Running            0          43m
user-load-66bd966d98-vhvh6     0/1     CrashLoopBackOff   12         43m
```

- Here are the logs with above changes

```
root@demo:~/zebrium-kubernetes-demo# ./manage.py test
Starting Litmus ChaosEngine Experiments...
chaosengine.litmuschaos.io/sock-chaos created
wait till the experiment execution is completed
wait till the experiment execution is completed
wait till the experiment execution is completed
wait till the experiment execution is completed
wait till the experiment execution is completed
kubectl describe chaosresult sock-chaos-container-kill -n sock-shop
Name:         sock-chaos-container-kill
Namespace:    sock-shop
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"litmuschaos.io/v1alpha1","kind":"ChaosResult","metadata":{"annotations":{},"name":"sock-chaos-container-kill","namespace":"...
API Version:  litmuschaos.io/v1alpha1
Kind:         ChaosResult
Metadata:
  Creation Timestamp:  2020-01-18T13:16:52Z
  Generation:          8
  Resource Version:    31545
  Self Link:           /apis/litmuschaos.io/v1alpha1/namespaces/sock-shop/chaosresults/sock-chaos-container-kill
  UID:                 cabb8f02-39f4-11ea-b161-42010a80019d
Spec:
  Experimentstatus:
    Phase:    <nil>
    Verdict:  pass
Events:       <none>
```
- Status of the chaosengine post execution

```
root@demo:~# kubectl get chaosengine sock-chaos -o yaml -n sock-shop
apiVersion: litmuschaos.io/v1alpha1
kind: ChaosEngine
metadata:
  creationTimestamp: 2020-01-18T14:54:29Z
  generation: 13
  name: sock-chaos
  namespace: sock-shop
  resourceVersion: "31569"
  selfLink: /apis/litmuschaos.io/v1alpha1/namespaces/sock-shop/chaosengines/sock-chaos
  uid: 6df7ce98-3a02-11ea-b161-42010a80019d
spec:
  appinfo:
    appkind: deployment
    applabel: name=carts-db
    appns: sock-shop
  chaosServiceAccount: sock-shop-chaos-engine
  components:
    monitor:
      image: ""
    runner:
      image: litmuschaos/chaos-executor:1.0.0
      type: go
  experiments:
  - name: container-kill
    spec:
      components:
      - name: TARGET_CONTAINER
        value: carts-db
      rank: 0
  jobCleanUpPolicy: delete
status:
  experiments:
  - lastUpdateTime: 2020-01-18T14:55:26Z
    name: container-kill-vegxzt
    status: Execution Successful
    verdict: pass
```
