### PR TITLE
(refactor) provide cluster-wide permissions to chaos serviceaccount and add resource definition to carts-db deploy

### DIFF
--- a/deploy/litmus-rbac.yaml
+++ b/deploy/litmus-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: sock-shop
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: sock-shop-chaos-engine
@@ -17,13 +17,13 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "jobs", "pods", "pods/exec","nodes","events", "chaosengines", "chaosexperiments", "chaosresults"]
   verbs: ["*"]
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: sock-shop-chaos-engine
   namespace: sock-shop
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: sock-shop-chaos-engine
   apiGroup: rbac.authorization.k8s.io
 subjects:

--- a/deploy/sock-shop.yaml
+++ b/deploy/sock-shop.yaml
@@ -27,6 +27,11 @@ spec:
         ports:
         - name: mongo
           containerPort: 27017
+        resources:
+          requests:
+            ephemeral-storage: "1Gi"
+          limits:
+            ephemeral-storage: "2Gi"
         securityContext:
           capabilities:
             drop:

--- a/litmus/disk-fill.yaml
+++ b/litmus/disk-fill.yaml
@@ -30,4 +30,4 @@ spec:
           - name: FILL_PERCENTAGE
             value: "80"
           - name: TARGET_CONTAINER
-            value: "cards-db"
+            value: "carts-db"


### PR DESCRIPTION
## Issue 

- Node level CPU Hog experiment was seen to fail because of the inability to derive the node name of the app pod prior to injection of chaos. This task (uses k8s_facts ansible module which in turn uses the openshift python client) requires cluster-wide scope for successful operation. Moreover, the cpu-hog experiment is classified as an "infra-level" chaos that might impact more than one app spread across ns & is therefore expected to be executed with cluster-wide permissions (the other type being "app-level" chaos, which is typically namespace scoped with lesser blast radius)

- Container Disk Fill experiment was seen to fail (apart from a minor typo in chaosengine) because the carts-db deployment did not have the ephemeral storage resource defined in its deployment spec. The DIsk Fill experiment works only when this is provided (https://docs.litmuschaos.io/docs/disk-fill/). 

  Note: Just an FYI. Litmuschaos will be adding disk-stress (IO-stress) experiments in subsequent releases which may not need resource definitions & can be a substitute to current experiment in representing "disk" chaos. The current disk-fill experiment however, has the benefit of being able to test evictions & eventual recovery due to storage limit breach. 

## Changes

- This PR provides the sock-shop- chaos-engine serviceaccount with cluster-wide permissions. 

- Adds a minimal ephemeral storage resource request/limit definition in the carts-db spec in order to enable the disk-experiment to determine the file size in the containerfs.  The values were selected based on the data stored/required in the demo sock-shop setup and considering it is more for illustration purposes.  


Signed-off-by: ksatchit <karthik.s@mayadata.io>