### PR TITLE
(enhancement) add ramp time for individual experiments to delay chaos injection

### DIFF
--- a/litmus/container-kill.yaml
+++ b/litmus/container-kill.yaml
@@ -28,3 +28,5 @@ spec:
         components:
         - name: TARGET_CONTAINER
           value: carts-db
+        - name: RAMP_TIME
+          value: "660"

--- a/litmus/cpu-hog.yaml
+++ b/litmus/cpu-hog.yaml
@@ -32,3 +32,5 @@ spec:
           # chaos lib used to inject the chaos
           - name: LIB
             value: 'litmus'
+          - name: RAMP_TIME
+            value: "660"

--- a/litmus/disk-fill.yaml
+++ b/litmus/disk-fill.yaml
@@ -31,3 +31,5 @@ spec:
             value: "80"
           - name: TARGET_CONTAINER
             value: "carts-db"
+          - name: RAMP_TIME
+            value: "660"

--- a/litmus/pod-cpu-hog.yaml
+++ b/litmus/pod-cpu-hog.yaml
@@ -35,3 +35,5 @@ spec:
             # in ms
           - name: TOTAL_CHAOS_DURATION
             value: "60000"
+          - name: RAMP_TIME
+            value: "660"

--- a/litmus/pod-delete.yaml
+++ b/litmus/pod-delete.yaml
@@ -35,3 +35,5 @@ spec:
           # pod failures without '--force' & default terminationGracePeriodSeconds
           - name: FORCE
             value: "false"
+          - name: RAMP_TIME
+            value: "660"

--- a/litmus/pod-network-corruption.yaml
+++ b/litmus/pod-network-corruption.yaml
@@ -34,3 +34,5 @@ spec:
         - name: NETWORK_INTERFACE
           #Network interface inside target container
           value: eth0
+        - name: RAMP_TIME
+          value: "660"

--- a/litmus/pod-network-latency.yaml
+++ b/litmus/pod-network-latency.yaml
@@ -42,3 +42,5 @@ spec:
             value: "60000"
           - name: LIB
             value: pumba
+          - name: RAMP_TIME
+            value: "660"

--- a/litmus/pod-network-loss.yaml
+++ b/litmus/pod-network-loss.yaml
@@ -42,3 +42,5 @@ spec:
               value: "60000"
             - name: LIB
               value: pumba
+            - name: RAMP_TIME
+              value: "660"


### PR DESCRIPTION
## Issue

- Refer https://github.com/litmuschaos/litmus/issues/1152

## Changes

- Introduces an optional delay/warm-up period prior to injection of chaos after all components of chaos infra are loaded. Provided as an ENV variable called "RAMP_TIME" (in seconds) 
- Updates chaosengine manifests to add a default RAMP_TIME of 660s. 

**Note**: In case of network chaos experiments, that use a scratch-based pumba job to inject chaos, the final component's (pumba job) creation is delayed per RAMP_TIME set.   

Signed-off-by: ksatchit <karthik.s@mayadata.io>