### PR TITLE
(fix) fix rbac for kafka chaos

### DIFF
--- a/deploy/litmus-rbac.yaml
+++ b/deploy/litmus-rbac.yaml
@@ -42,7 +42,7 @@ metadata:
   namespace: kafka
 rules:
 - apiGroups: ["", "extensions", "apps", "batch", "litmuschaos.io"]
-  resources:  ["pods","deployments","jobs","pod/exec","statefulsets", "nodes", "configmaps", "secrets","chaosengines","chaosexperiments","chaosresults"]
+  resources:  ["pods","deployments","jobs","pods/exec","statefulsets", "nodes", "configmaps", "secrets","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["*"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Changes

- Fixes a bug (type) in the litmus-rbac file for kafka chaos that was causing the following error: 

```
2020-02-12 01:14:51.875426 Step: Obtain the leader broker ordinality for the topic (partition) created by kafka-liveness
task path: /utils/apps/kafka/kafka_liveness_stream.yml:48
details => {"changed": true, "cmd": "kubectl exec kafka-liveness -n kafka -c kafka-consumer -- kafka-topics --topic topic-6P9tzBnUbF --describe --zookeeper kafka-cluster-cp-zookeeper-headless:2181 | grep -o 'Leader: [^[:space:]]*' | awk '{print $2}'", "delta": "0:00:00.949140", "end": "2020-02-12 01:14:51.736497", "failed_when_result": false, "rc": 0, "start": "2020-02-12 01:14:50.787357", "stderr": "Error from server (Forbidden): pods \"kafka-liveness\" is forbidden: User \"system:serviceaccount:kafka:kafka-chaos-engine\" cannot create resource \"pods/exec\" in API group \"\" in the namespace \"kafka\"", "stderr_lines": ["Error from server (Forbidden): pods \"kafka-liveness\" is forbidden: User \"system:serviceaccount:kafka:kafka-chaos-engine\" cannot create resource \"pods/exec\" in API group \"\" in the namespace \"kafka\""], "stdout": "", "stdout_lines": []}
```


Signed-off-by: ksatchit <ksatchit@mayadata.io>