### PR TITLE
(refactor): update engine schema to reflect latest changes in litmus

### DIFF
--- a/litmus/container-kill.yaml
+++ b/litmus/container-kill.yaml
@@ -4,14 +4,11 @@ metadata:
   name: sock-chaos
   namespace: sock-shop
 spec:
-  # It can be app/infra
-  chaosType: 'app'
+  # It can be true/false
+  annotationCheck: 'true'
+  engineState: 'active'
   #ex. values: sock-shop:name=carts
   auxiliaryAppInfo: ""
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
   # It can be delete/retain
   jobCleanUpPolicy: delete
   monitoring: true
@@ -26,5 +23,6 @@ spec:
     - name: container-kill
       spec:
         components:
-        - name: TARGET_CONTAINER
-          value: carts-db
+          env:
+            - name: TARGET_CONTAINER
+              value: carts-db

--- a/litmus/disk-fill.yaml
+++ b/litmus/disk-fill.yaml
@@ -4,14 +4,11 @@ metadata:
   name: sock-chaos
   namespace: sock-shop
 spec:
-  # It can be app/infra
-  chaosType: 'app'
+  # It can be true/false
+  annotationCheck: 'false'
   #ex. values: sock-shop:name=carts
   auxiliaryAppInfo: ""
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
+  engineState: 'active'
   # It can be delete/retain
   jobCleanUpPolicy: delete
   monitoring: true
@@ -26,8 +23,9 @@ spec:
     - name: disk-fill
       spec:
         components:
-           # specify the fill percentage according to the disk pressure required
-          - name: FILL_PERCENTAGE
-            value: "80"
-          - name: TARGET_CONTAINER
-            value: "carts-db"
+          env:
+            # specify the fill percentage according to the disk pressure required
+            - name: FILL_PERCENTAGE
+              value: "80"
+            - name: TARGET_CONTAINER
+              value: "carts-db"

--- a/litmus/kafka-broker-pod-failure.yaml
+++ b/litmus/kafka-broker-pod-failure.yaml
@@ -4,72 +4,70 @@ metadata:
   name: kafka-chaos
   namespace: kafka
 spec:
-  # It can be app/infra
-  chaosType: 'app'
+  # It can be true/false
+  annotationCheck: 'true'
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ""
+  engineState: 'active'
   appinfo:
     appns: kafka
     applabel: 'app=cp-kafka'
     appkind: statefulset
   chaosServiceAccount: kafka-chaos-engine
   monitoring: true
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
   # It can be delete/retain
   jobCleanUpPolicy: delete
   experiments:
     - name: kafka-broker-pod-failure
       spec:
         components:
-          # choose based on available kafka broker replicas
-          - name: KAFKA_REPLICATION_FACTOR
-            value: '3'
+          env: 
+            # choose based on available kafka broker replicas
+            - name: KAFKA_REPLICATION_FACTOR
+              value: '3'
 
-          # get via "kubectl get pods --show-labels -n <kafka-namespace>"
-          - name: KAFKA_LABEL
-            value: 'app=cp-kafka'
+            # get via "kubectl get pods --show-labels -n <kafka-namespace>"
+            - name: KAFKA_LABEL
+              value: 'app=cp-kafka'
 
-          - name: KAFKA_NAMESPACE
-            value: 'kafka'
+            - name: KAFKA_NAMESPACE
+              value: 'kafka'
 
-          # get via "kubectl get svc -n <kafka-namespace>"
-          - name: KAFKA_SERVICE
-            value: 'kafka-cluster-cp-kafka-headless'
+            # get via "kubectl get svc -n <kafka-namespace>"
+            - name: KAFKA_SERVICE
+              value: 'kafka-cluster-cp-kafka-headless'
 
-          # get via "kubectl get svc -n <kafka-namespace>
-          - name: KAFKA_PORT
-            value: '9092'
+            # get via "kubectl get svc -n <kafka-namespace>
+            - name: KAFKA_PORT
+              value: '9092'
 
-          # in milliseconds
-          - name: KAFKA_CONSUMER_TIMEOUT
-            value: '70000'
+            # in milliseconds
+            - name: KAFKA_CONSUMER_TIMEOUT
+              value: '70000'
 
-          - name: ZOOKEEPER_NAMESPACE
-            value: 'kafka'
+            - name: ZOOKEEPER_NAMESPACE
+              value: 'kafka'
 
-          # get via "kubectl get pods --show-labels -n <zk-namespace>"
-          - name: ZOOKEEPER_LABEL
-            value: 'app=cp-zookeeper'
+            # get via "kubectl get pods --show-labels -n <zk-namespace>"
+            - name: ZOOKEEPER_LABEL
+              value: 'app=cp-zookeeper'
 
-          # get via "kubectl get svc -n <zk-namespace>
-          - name: ZOOKEEPER_SERVICE
-            value: 'kafka-cluster-cp-zookeeper-headless'
+            # get via "kubectl get svc -n <zk-namespace>
+            - name: ZOOKEEPER_SERVICE
+              value: 'kafka-cluster-cp-zookeeper-headless'
 
-          # get via "kubectl get svc -n <zk-namespace>
-          - name: ZOOKEEPER_PORT
-            value: '2181'
+            # get via "kubectl get svc -n <zk-namespace>
+            - name: ZOOKEEPER_PORT
+              value: '2181'
 
-          # set chaos duration (in sec) as desired
-          - name: TOTAL_CHAOS_DURATION
-            value: '60'
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
 
-          # set chaos interval (in sec) as desired
-          - name: CHAOS_INTERVAL
-            value: '20'
+            # set chaos interval (in sec) as desired
+            - name: CHAOS_INTERVAL
+              value: '20'
 
-          # pod failures without '--force' & default terminationGracePeriodSeconds
-          - name: FORCE
-            value: "false"
+            # pod failures without '--force' & default terminationGracePeriodSeconds
+            - name: FORCE
+              value: "false"

--- a/litmus/node-cpu-hog.yaml
+++ b/litmus/node-cpu-hog.yaml
@@ -4,31 +4,30 @@ metadata:
   name: sock-chaos
   namespace: sock-shop
 spec:
-  chaosType: 'infra'  # It can be app/infra
+  # It can be app/infra
+  annotationCheck: 'false'
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ""
+  engineState: 'active'
   appinfo:
     appns: sock-shop
     applabel: 'name=carts-db'
     appkind: deployment
   chaosServiceAccount: sock-shop-chaos-engine
   monitoring: true
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
   # It can be delete/retain
   jobCleanUpPolicy: delete
   experiments:
     - name: node-cpu-hog
       spec:
         components:
-           # set chaos duration (in sec) as desired
-          - name: TOTAL_CHAOS_DURATION
-            value: '60'
-          # set chaos platform as desired
-          - name: PLATFORM
-            value: 'GKE'
-          # chaos lib used to inject the chaos
-          - name: LIB
-            value: 'litmus'
+          env: 
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
+            # set chaos platform as desired
+            - name: PLATFORM
+              value: 'GKE'
+            # chaos lib used to inject the chaos
+            - name: LIB
+              value: 'litmus'

--- a/litmus/pod-cpu-hog.yaml
+++ b/litmus/pod-cpu-hog.yaml
@@ -4,14 +4,11 @@ metadata:
   name: sock-chaos
   namespace: sock-shop
 spec:
-  # It can be app/infra
-  chaosType: 'app'
+  # It can be true/false
+  annotationCheck: 'true'
   #ex. values: sock-shop:name=carts
   auxiliaryAppInfo: ""
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
+  engineState: 'active'
   # It can be delete/retain
   jobCleanUpPolicy: delete
   monitoring: true
@@ -26,12 +23,13 @@ spec:
     - name: pod-cpu-hog
       spec:
         components:
-          - name: TARGET_CONTAINER
-            value: 'carts-db'
-            #number of cpu cores to be consumed
-            #verify the resources the app has been launched with
-          - name: CPU_CORES
-            value: "1"
-            # in ms
-          - name: TOTAL_CHAOS_DURATION
-            value: "60000"
+          env:
+            - name: TARGET_CONTAINER
+              value: 'carts-db'
+              #number of cpu cores to be consumed
+              #verify the resources the app has been launched with
+            - name: CPU_CORES
+              value: "1"
+              # in ms
+            - name: TOTAL_CHAOS_DURATION
+              value: "60000"

--- a/litmus/pod-delete.yaml
+++ b/litmus/pod-delete.yaml
@@ -5,13 +5,10 @@ metadata:
   namespace: sock-shop
 spec:
   # It can be app/infra
-  chaosType: 'app'
+  annotationCheck: 'true'
+  engineState: 'active'
   #ex. values: sock-shop:name=carts
   auxiliaryAppInfo: ""
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
   # It can be delete/retain
   jobCleanUpPolicy: delete
   monitoring: true
@@ -26,12 +23,13 @@ spec:
     - name: pod-delete
       spec:
         components:
-           # set chaos duration (in sec) as desired
-          - name: TOTAL_CHAOS_DURATION
-            value: '30'
-          # set chaos interval (in sec) as desired
-          - name: CHAOS_INTERVAL
-            value: '10'
-          # pod failures without '--force' & default terminationGracePeriodSeconds
-          - name: FORCE
-            value: "false"
+          env: 
+             # set chaos duration (in sec) as desired
+             - name: TOTAL_CHAOS_DURATION
+               value: '30'
+             # set chaos interval (in sec) as desired
+             - name: CHAOS_INTERVAL
+               value: '10'
+             # pod failures without '--force' & default terminationGracePeriodSeconds
+             - name: FORCE
+               value: "false"

--- a/litmus/pod-network-corruption.yaml
+++ b/litmus/pod-network-corruption.yaml
@@ -4,14 +4,11 @@ metadata:
   name: sock-chaos
   namespace: sock-shop
 spec:
-  # It can be app/infra
-  chaosType: 'app'
+  # It can be true/false
+  annotationCheck: 'true'
   #ex. values: sock-shop:name=carts
   auxiliaryAppInfo: ""
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
+  engineState: 'active'
   # It can be delete/retain
   jobCleanUpPolicy: delete
   monitoring: true
@@ -26,11 +23,12 @@ spec:
     - name: pod-network-corruption
       spec:
         components:
-        - name: ANSIBLE_STDOUT_CALLBACK
-          value: default
-        - name: TARGET_CONTAINER
-          #Container name where chaos has to be injected
-          value: "carts-db"
-        - name: NETWORK_INTERFACE
-          #Network interface inside target container
-          value: eth0
+          env:
+            - name: ANSIBLE_STDOUT_CALLBACK
+              value: default
+              #Container name where chaos has to be injected
+            - name: TARGET_CONTAINER
+              value: "carts-db"
+              #Network interface inside target container
+            - name: NETWORK_INTERFACE
+              value: eth0

--- a/litmus/pod-network-latency.yaml
+++ b/litmus/pod-network-latency.yaml
@@ -4,14 +4,11 @@ metadata:
   name: sock-chaos
   namespace: sock-shop
 spec:
-  # It can be app/infra
-  chaosType: 'app'
-  #ex. values: sock-shop:name=carts
+  # It can be true/false
+  annotationCheck: 'true'
+  # ex. values: sock-shop:name=carts
+  engineState: 'active'
   auxiliaryAppInfo: ""
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
   # It can be delete/retain
   jobCleanUpPolicy: delete
   monitoring: true
@@ -26,19 +23,20 @@ spec:
     - name: pod-network-latency
       spec:
         components:
-          - name: ANSIBLE_STDOUT_CALLBACK
-            value: default
-          - name: TARGET_CONTAINER
-            #Container name where chaos has to be injected
-            value: "carts-db"
-          - name: NETWORK_INTERFACE
-            #Network interface inside target container
-            value: eth0
-          - name: LIB_IMAGE
-            value: gaiaadm/pumba:0.6.5
-          - name: NETWORK_LATENCY
-            value: "2000"
-          - name: TOTAL_CHAOS_DURATION
-            value: "60000"
-          - name: LIB
-            value: pumba
+          env:
+            - name: ANSIBLE_STDOUT_CALLBACK
+              value: default
+              #Container name where chaos has to be injected
+            - name: TARGET_CONTAINER
+              value: "carts-db"
+              #Network interface inside target container
+            - name: NETWORK_INTERFACE
+              value: eth0
+            - name: LIB_IMAGE
+              value: gaiaadm/pumba:0.6.5
+            - name: NETWORK_LATENCY
+              value: "2000"
+            - name: TOTAL_CHAOS_DURATION
+              value: "60000"
+            - name: LIB
+              value: pumba

--- a/litmus/pod-network-loss.yaml
+++ b/litmus/pod-network-loss.yaml
@@ -4,14 +4,11 @@ metadata:
   name: sock-chaos
   namespace: sock-shop
 spec:
-  # It can be app/infra
-  chaosType: 'app'
+  # It can be true/false
+  annotationCheck: 'true'
   #ex. values: sock-shop:name=carts
   auxiliaryAppInfo: ""
-  components:
-    runner:
-      image: "litmuschaos/chaos-executor:1.0.0"
-      type: "go"
+  engineState: 'active'
   # It can be delete/retain
   jobCleanUpPolicy: delete
   monitoring: true
@@ -26,6 +23,7 @@ spec:
     - name: pod-network-loss
       spec:
         components:
+          env:
             - name: ANSIBLE_STDOUT_CALLBACK
               value: default
             - name: TARGET_CONTAINER

--- a/manage.py
+++ b/manage.py
@@ -84,7 +84,7 @@ def start(args):
     run_shell('kubectl annotate sts/kafka-cluster-cp-kafka litmuschaos.io/chaos="true" -n kafka')
 
     # Deploy Litmus ChaosOperator to run Experiments that create incidents
-    run_shell("kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-v1.0.0.yaml")
+    run_shell("kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-latest.yaml")
 
     # Install Litmus Experiments
     run_shell("kubectl create -f https://hub.litmuschaos.io/api/chaos?file=charts/generic/experiments.yaml -n sock-shop")
@@ -154,7 +154,7 @@ def run_experiment(experiment: str, delay: int = 0):
 
         # Create temp file with updated RAMP_TIME
         if (delay > 0):
-            spec['spec']['experiments'][0]['spec']['components'].append({'name': 'RAMP_TIME', 'value': str(delay)})
+            spec['spec']['experiments'][0]['spec']['components']['env'].append({'name': 'RAMP_TIME', 'value': str(delay)})
         with open(r"temp.yaml", 'w') as temp:
             yaml.dump(spec, temp)
 


### PR DESCRIPTION
### Changes: 

- The Litmus release 1.1 (scheduled for Feb 15, RC under test) introduces changes to the ChaosEngine schema & the experiment definitions in order to support abort workflow and overrides for experiment components

- The `ansible-runner:latest` image used in the ChaosExperiment CRs (pulled from the hub) contained changes to support the above (essentially addition of labels to dependent resources in experiments. You can notice that experiments that didn't include creation of secondary resources, i.e., pod-delete & node-cpu-hog passed). 

- These are breaking changes that caused experiment failures.      

- This PR includes the updated operator YAML and engine schema to fix the above failures. 

With this all tests run successfully. We shall version the experiment charts along w/ the operator & docs in upcoming releases to ensure there is a working set for each release. 

Sorry for the inconvenience, David!! 

Signed-off-by: ksatchit <karthik.s@mayadata.io>